### PR TITLE
Fix "Since" field for al_x_set_initial_icon in docs

### DIFF
--- a/docs/src/refman/platform.txt
+++ b/docs/src/refman/platform.txt
@@ -177,4 +177,4 @@ doesn't work and you need to use a .desktop file. But with this function
 you can set an icon before calling al_create_display. This works
 by setting the icon before XMapWindow.
 
-Since: 5.2.1.2
+Since: 5.2.3


### PR DESCRIPTION
5.2.2 has been already released and doesn't contain al_x_set_initial_icon function. 
It's now 5.2.3 in git, so let's set it as that.